### PR TITLE
Correct buildout error: A 0.7-series setuptools cannot be installed with distribute.

### DIFF
--- a/distribute_setup.py
+++ b/distribute_setup.py
@@ -49,7 +49,7 @@ except ImportError:
             args = [quote(arg) for arg in args]
         return os.spawnl(os.P_WAIT, sys.executable, *args) == 0
 
-DEFAULT_VERSION = "0.6.34"
+DEFAULT_VERSION = "0.7.3"
 DEFAULT_URL = "http://pypi.python.org/packages/source/d/distribute/"
 SETUPTOOLS_FAKED_VERSION = "0.6c11"
 

--- a/distribute_setup.py
+++ b/distribute_setup.py
@@ -49,7 +49,7 @@ except ImportError:
             args = [quote(arg) for arg in args]
         return os.spawnl(os.P_WAIT, sys.executable, *args) == 0
 
-DEFAULT_VERSION = "0.7.3"
+DEFAULT_VERSION = "0.6.49"
 DEFAULT_URL = "http://pypi.python.org/packages/source/d/distribute/"
 SETUPTOOLS_FAKED_VERSION = "0.6c11"
 

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     keywords='xmpp chat messaging',
     author='JC Brand',
     author_email='jc@opkode.com',
-    url='https://github.com/ShuffleBox/collective.xmpp.chat',
+    url='https://github.com/collective/collective.xmpp.chat',
     license='GPL',
     packages=find_packages('src', exclude=['ez_setup']),
     package_dir={'': 'src'},

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     keywords='xmpp chat messaging',
     author='JC Brand',
     author_email='jc@opkode.com',
-    url='https://github.com/collective/collective.xmpp.chat',
+    url='https://github.com/ShuffleBox/collective.xmpp.chat',
     license='GPL',
     packages=find_packages('src', exclude=['ez_setup']),
     package_dir={'': 'src'},


### PR DESCRIPTION
I ran into the issue below, while running buildout on a vanilla Plone 4.3.3 site with collective.xmpp.chat/core.  Updating the version of distribute called by distribute_setup.py  from 0.6.34 to 0.6.49 (latest in the 0.6.x line) has corrected the issue.

<pre>
<code>
Getting distribution for 'collective.xmpp.chat'.
Downloading http://pypi.python.org/packages/source/d/distribute/distribute-0.6.34.tar.gz
Extracting in /var/folders/v_/439fk7756s552r4wwc49zzm80000gn/T/easy_install-pN1S5L/collective.xmpp.chat-0.3.1/temp/tmpT70Nln
Now working in /var/folders/v_/439fk7756s552r4wwc49zzm80000gn/T/easy_install-pN1S5L/collective.xmpp.chat-0.3.1/temp/tmpT70Nln/distribute-0.6.34
Building a Distribute egg in /private/var/folders/v_/439fk7756s552r4wwc49zzm80000gn/T/easy_install-pN1S5L/collective.xmpp.chat-0.3.1
Traceback (most recent call last):
  File "setup.py", line 45, in <module>
    exec(init_file.read(), d)
  File "<string>", line 8, in <module>
  File "/private/var/folders/v_/439fk7756s552r4wwc49zzm80000gn/T/easy_install-pN1S5L/collective.xmpp.chat-0.3.1/temp/tmpT70Nln/distribute-0.6.34/setuptools/__init__.py", line 2, in <module>
    from setuptools.extension import Extension, Library
  File "/private/var/folders/v_/439fk7756s552r4wwc49zzm80000gn/T/easy_install-pN1S5L/collective.xmpp.chat-0.3.1/temp/tmpT70Nln/distribute-0.6.34/setuptools/extension.py", line 5, in <module>
    from setuptools.dist import _get_unpatched
  File "/private/var/folders/v_/439fk7756s552r4wwc49zzm80000gn/T/easy_install-pN1S5L/collective.xmpp.chat-0.3.1/temp/tmpT70Nln/distribute-0.6.34/setuptools/dist.py", line 6, in <module>
    from setuptools.command.install import install
  File "/private/var/folders/v_/439fk7756s552r4wwc49zzm80000gn/T/easy_install-pN1S5L/collective.xmpp.chat-0.3.1/temp/tmpT70Nln/distribute-0.6.34/setuptools/command/__init__.py", line 8, in <module>
    from setuptools.command import install_scripts
  File "/private/var/folders/v_/439fk7756s552r4wwc49zzm80000gn/T/easy_install-pN1S5L/collective.xmpp.chat-0.3.1/temp/tmpT70Nln/distribute-0.6.34/setuptools/command/install_scripts.py", line 3, in <module>
    from pkg_resources import Distribution, PathMetadata, ensure_directory
  File "/private/var/folders/v_/439fk7756s552r4wwc49zzm80000gn/T/easy_install-pN1S5L/collective.xmpp.chat-0.3.1/temp/tmpT70Nln/distribute-0.6.34/pkg_resources.py", line 2823, in <module>
    add_activation_listener(lambda dist: dist.activate())
  File "/private/var/folders/v_/439fk7756s552r4wwc49zzm80000gn/T/easy_install-pN1S5L/collective.xmpp.chat-0.3.1/temp/tmpT70Nln/distribute-0.6.34/pkg_resources.py", line 710, in subscribe
    callback(dist)
  File "/private/var/folders/v_/439fk7756s552r4wwc49zzm80000gn/T/easy_install-pN1S5L/collective.xmpp.chat-0.3.1/temp/tmpT70Nln/distribute-0.6.34/pkg_resources.py", line 2823, in <lambda>
    add_activation_listener(lambda dist: dist.activate())
  File "/private/var/folders/v_/439fk7756s552r4wwc49zzm80000gn/T/easy_install-pN1S5L/collective.xmpp.chat-0.3.1/temp/tmpT70Nln/distribute-0.6.34/pkg_resources.py", line 2255, in activate
    self.insert_on(path)
  File "/private/var/folders/v_/439fk7756s552r4wwc49zzm80000gn/T/easy_install-pN1S5L/collective.xmpp.chat-0.3.1/temp/tmpT70Nln/distribute-0.6.34/pkg_resources.py", line 2356, in insert_on
    "with distribute. Found one at %s" % str(self.location))
ValueError: A 0.7-series setuptools cannot be installed with distribute. Found one at /Users/garret/xmpptest/Vanilla/buildout-cache/eggs/setuptools-0.7.2-py2.7.egg
/private/var/folders/v_/439fk7756s552r4wwc49zzm80000gn/T/easy_install-pN1S5L/collective.xmpp.chat-0.3.1/distribute-0.6.34-py2.7.egg
error: None
An error occurred when trying to install collective.xmpp.chat 0.3.1. Look above this message for any errors that were output by easy_install.
</code>
</pre>
